### PR TITLE
Update ConflictList.php

### DIFF
--- a/Block/Adminhtml/ConflictList.php
+++ b/Block/Adminhtml/ConflictList.php
@@ -142,7 +142,7 @@ class ConflictList extends \Magento\Backend\Block\Template
      */
     protected function normilizeClass($class)
     {
-        if ($class && $class{0} != '\\') {
+        if ($class && $class[0] != '\\') {
             $class = '\\' . $class;
         }
 


### PR DESCRIPTION
fix error : Deprecated Functionality: Array and string offset access syntax with curly   
  braces is deprecated in /var/www/html/glamira2/vendor/magefan/module-confli  
  ct-detector/Block/Adminhtml/ConflictList.php on line 145 
when run bin/magento setup:di:compile